### PR TITLE
feat: add chart export as PNG and JPG functionality

### DIFF
--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -250,19 +250,23 @@
 
             <div class="col-span-12 lg:col-span-8">
               <div class="glass-card p-6 min-h-[500px]">
-                <h4
-                  class="text-[10px] font-bold uppercase text-slate-500 mb-6 tracking-widest"
-                >
-                  Integrity Delta Visualization
-                </h4>
-                <div class="h-[400px] w-full">
-                  <canvas id="timelineChart"></canvas>
-                </div>
-              </div>
-            </div>
-          </div>
+    <div class="flex justify-between items-center mb-6">
+        <h4 class="text-[10px] font-bold uppercase text-slate-500 tracking-widest">
+            Integrity Delta Visualization
+        </h4>
+        <div class="flex gap-2">
+            <button onclick="exportChartAsPNG()" class="text-[9px] bg-blue-600/20 hover:bg-blue-600/40 text-blue-400 px-3 py-1.5 rounded-lg transition-all flex items-center gap-1.5 font-bold uppercase tracking-wider">
+                <i class="fas fa-file-image text-xs"></i> PNG
+            </button>
+            <button onclick="exportChartAsJPG()" class="text-[9px] bg-emerald-600/20 hover:bg-emerald-600/40 text-emerald-400 px-3 py-1.5 rounded-lg transition-all flex items-center gap-1.5 font-bold uppercase tracking-wider">
+                <i class="fas fa-camera text-xs"></i> JPG
+            </button>
         </div>
-
+    </div>
+    <div class="h-[400px] w-full">
+        <canvas id="timelineChart"></canvas>
+    </div>
+</div>
         <div
           id="view-registry"
           class="tab-view hidden glass-card overflow-hidden"

--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -13,288 +13,118 @@
     <link rel="stylesheet" href="../styles/dashboard.css" />
   </head>
   <body class="flex min-h-screen">
-    <div
-      id="scanOverlay"
-      class="hidden fixed inset-0 bg-[#020617]/95 backdrop-blur-xl z-[100] flex items-center justify-center"
-    >
+    <!-- Scan Overlay -->
+    <div id="scanOverlay" class="hidden fixed inset-0 bg-[#020617]/95 backdrop-blur-xl z-[100] flex items-center justify-center">
       <div class="text-center">
         <div class="relative w-24 h-24 mx-auto mb-8">
-          <div
-            class="absolute inset-0 border-4 border-blue-500/10 border-t-blue-500 rounded-full animate-spin"
-          ></div>
-          <div
-            class="absolute inset-4 bg-blue-600/20 rounded-full flex items-center justify-center"
-          >
+          <div class="absolute inset-0 border-4 border-blue-500/10 border-t-blue-500 rounded-full animate-spin"></div>
+          <div class="absolute inset-4 bg-blue-600/20 rounded-full flex items-center justify-center">
             <i class="fas fa-fingerprint text-blue-500 text-3xl"></i>
           </div>
         </div>
-        <h3
-          class="text-white font-black tracking-[0.4em] uppercase text-sm mb-3"
-        >
-          Forensic Deep Scan
-        </h3>
-        <p
-          id="loaderStatus"
-          class="text-blue-500/60 font-mono text-[10px] uppercase"
-        >
-          Initializing data buffers...
-        </p>
+        <h3 class="text-white font-black tracking-[0.4em] uppercase text-sm mb-3">Forensic Deep Scan</h3>
+        <p id="loaderStatus" class="text-blue-500/60 font-mono text-[10px] uppercase">Initializing data buffers...</p>
       </div>
     </div>
 
-    <div
-      id="toast"
-      class="fixed bottom-10 right-10 transform translate-y-24 opacity-0 z-[200] bg-blue-600 text-white px-6 py-3 rounded-xl shadow-2xl flex items-center gap-3"
-    >
+    <!-- Toast -->
+    <div id="toast" class="fixed bottom-10 right-10 transform translate-y-24 opacity-0 z-[200] bg-blue-600 text-white px-6 py-3 rounded-xl shadow-2xl flex items-center gap-3">
       <i class="fas fa-shield-check"></i>
       <span id="toastMsg">System Ready</span>
     </div>
 
-    <nav
-      class="w-64 border-r border-white/5 bg-slate-950/50 flex flex-col p-6 shrink-0 z-50"
-    >
+    <!-- Sidebar -->
+    <nav class="w-64 border-r border-white/5 bg-slate-950/50 flex flex-col p-6 shrink-0 z-50">
       <div class="flex items-center gap-3 mb-10 px-2">
         <i class="fas fa-shield-halved text-blue-500 text-2xl"></i>
-        <span
-          class="font-black tracking-tighter uppercase italic text-lg leading-tight"
-          >Evidence <br /><span class="text-blue-500 text-sm"
-            >Protector Pro</span
-          ></span
-        >
+        <span class="font-black tracking-tighter uppercase italic text-lg leading-tight">Evidence <br /><span class="text-blue-500 text-sm">Protector Pro</span></span>
       </div>
       <div class="space-y-1 flex-1 custom-scroll overflow-y-auto">
-        <p
-          class="text-[9px] font-bold text-slate-600 uppercase tracking-widest mb-3 px-2"
-        >
-          System Access
-        </p>
-        <a
-          href="index.html"
-          class="nav-item flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-medium"
-          ><i class="fas fa-house-chimney w-4"></i> Home</a
-        >
-
-        <p
-          class="text-[9px] font-bold text-slate-600 uppercase tracking-widest mt-8 mb-3 px-2"
-        >
-          Analysis Engine
-        </p>
-        <div
-          onclick="switchTab('dashboard')"
-          id="nav-dashboard"
-          class="nav-item active flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-medium"
-        >
-          <i class="fas fa-chart-pie w-4"></i> Dashboard
-        </div>
-        <div
-          onclick="switchTab('registry')"
-          id="nav-registry"
-          class="nav-item flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-medium"
-        >
-          <i class="fas fa-list-check w-4"></i> Registry
-        </div>
-
-        <p
-          class="text-[9px] font-bold text-slate-600 uppercase tracking-widest mt-8 mb-3 px-2"
-        >
-          Governance
-        </p>
-        <div
-          onclick="switchTab('compliance')"
-          id="nav-compliance"
-          class="nav-item flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-medium"
-        >
-          <i class="fas fa-file-contract w-4"></i> Export Center
-        </div>
+        <p class="text-[9px] font-bold text-slate-600 uppercase tracking-widest mb-3 px-2">System Access</p>
+        <a href="index.html" class="nav-item flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-medium"><i class="fas fa-house-chimney w-4"></i> Home</a>
+        <p class="text-[9px] font-bold text-slate-600 uppercase tracking-widest mt-8 mb-3 px-2">Analysis Engine</p>
+        <div onclick="switchTab('dashboard')" id="nav-dashboard" class="nav-item active flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-medium"><i class="fas fa-chart-pie w-4"></i> Dashboard</div>
+        <div onclick="switchTab('registry')" id="nav-registry" class="nav-item flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-medium"><i class="fas fa-list-check w-4"></i> Registry</div>
+        <p class="text-[9px] font-bold text-slate-600 uppercase tracking-widest mt-8 mb-3 px-2">Governance</p>
+        <div onclick="switchTab('compliance')" id="nav-compliance" class="nav-item flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-medium"><i class="fas fa-file-contract w-4"></i> Export Center</div>
       </div>
-      <button
-        onclick="logout()"
-        class="mt-4 flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-bold text-red-500/80 hover:bg-red-500/10 transition-all"
-      >
-        <i class="fas fa-power-off"></i> Logout
-      </button>
+      <button onclick="logout()" class="mt-4 flex items-center gap-4 py-3 px-4 rounded-xl text-sm font-bold text-red-500/80 hover:bg-red-500/10 transition-all"><i class="fas fa-power-off"></i> Logout</button>
     </nav>
 
+    <!-- Main Content -->
     <main class="flex-1 flex flex-col h-screen overflow-hidden">
-      <header
-        class="h-20 border-b border-white/5 bg-slate-950/20 backdrop-blur-md flex items-center justify-between px-8 shrink-0"
-      >
+      <header class="h-20 border-b border-white/5 bg-slate-950/20 backdrop-blur-md flex items-center justify-between px-8 shrink-0">
         <h2 id="viewTitle" class="text-lg font-bold">Executive Overview</h2>
-        <div
-          class="bg-slate-900 px-4 py-2 rounded-full border border-white/5 text-[9px] font-bold text-slate-500 uppercase"
-        >
-          Status: <span class="text-emerald-500">Active</span>
-        </div>
+        <div class="bg-slate-900 px-4 py-2 rounded-full border border-white/5 text-[9px] font-bold text-slate-500 uppercase">Status: <span class="text-emerald-500">Active</span></div>
       </header>
 
       <div class="flex-1 overflow-y-auto p-8 space-y-8 custom-scroll">
+        <!-- DASHBOARD TAB -->
         <div id="view-dashboard" class="tab-view space-y-6">
+          <!-- KPI Cards -->
           <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div class="glass-card p-5 border-t-2 border-blue-500">
-              <p class="text-[9px] text-slate-500 font-bold uppercase mb-1">
-                Integrity Score
-              </p>
-              <h3
-                id="integrityScoreCard"
-                class="text-2xl font-black text-white"
-              >
-                --%
-              </h3>
-            </div>
-            <div class="glass-card p-5 border-t-2 border-red-500">
-              <p class="text-[9px] text-slate-500 font-bold uppercase mb-1">
-                Compromise Risk
-              </p>
-              <h3 id="financialRisk" class="text-2xl font-black text-red-400">
-                0%
-              </h3>
-            </div>
-            <div class="glass-card p-5 border-t-2 border-purple-500">
-              <p class="text-[9px] text-slate-500 font-bold uppercase mb-1">
-                Gaps Detected
-              </p>
-              <h3 id="gapCount" class="text-2xl font-black text-white">0</h3>
-            </div>
-            <div class="glass-card p-5 border-t-2 border-emerald-500">
-              <p class="text-[9px] text-slate-500 font-bold uppercase mb-1">
-                Last Scan Session
-              </p>
-              <p
-                id="lastScanTime"
-                class="text-[10px] font-mono text-emerald-400 truncate"
-              >
-                Awaiting Data
-              </p>
-              <p
-                id="lastFileName"
-                class="text-[8px] text-slate-600 truncate mt-1"
-              >
-                --
-              </p>
-            </div>
+            <div class="glass-card p-5 border-t-2 border-blue-500"><p class="text-[9px] text-slate-500 font-bold uppercase mb-1">Integrity Score</p><h3 id="integrityScoreCard" class="text-2xl font-black text-white">--%</h3></div>
+            <div class="glass-card p-5 border-t-2 border-red-500"><p class="text-[9px] text-slate-500 font-bold uppercase mb-1">Compromise Risk</p><h3 id="financialRisk" class="text-2xl font-black text-red-400">0%</h3></div>
+            <div class="glass-card p-5 border-t-2 border-purple-500"><p class="text-[9px] text-slate-500 font-bold uppercase mb-1">Gaps Detected</p><h3 id="gapCount" class="text-2xl font-black text-white">0</h3></div>
+            <div class="glass-card p-5 border-t-2 border-emerald-500"><p class="text-[9px] text-slate-500 font-bold uppercase mb-1">Last Scan Session</p><p id="lastScanTime" class="text-[10px] font-mono text-emerald-400 truncate">Awaiting Data</p><p id="lastFileName" class="text-[8px] text-slate-600 truncate mt-1">--</p></div>
           </div>
 
+          <!-- Heatmap -->
           <div class="glass-card p-6">
-            <div class="flex justify-between items-center mb-4">
-              <h4
-                class="text-[10px] font-bold uppercase text-slate-500 tracking-[0.2em]"
-              >
-                Forensic Timeline Scrubber
-              </h4>
-              <div class="flex gap-4 text-[8px] font-bold uppercase">
-                <span class="text-emerald-500">● Nominal</span>
-                <span class="text-red-500">● Anomaly</span>
-              </div>
-            </div>
+            <div class="flex justify-between items-center mb-4"><h4 class="text-[10px] font-bold uppercase text-slate-500 tracking-[0.2em]">Forensic Timeline Scrubber</h4><div class="flex gap-4 text-[8px] font-bold uppercase"><span class="text-emerald-500">● Nominal</span><span class="text-red-500">● Anomaly</span></div></div>
             <div id="forensicHeatmap" class="heatmap-container mb-3"></div>
-            <div
-              class="flex justify-between text-[9px] font-mono text-slate-600 uppercase"
-            >
-              <span id="heatmap-start">00:00:00</span>
-              <span id="heatmap-end">23:59:59</span>
-            </div>
+            <div class="flex justify-between text-[9px] font-mono text-slate-600 uppercase"><span id="heatmap-start">00:00:00</span><span id="heatmap-end">23:59:59</span></div>
           </div>
 
+          <!-- Main Content Area -->
           <div class="grid grid-cols-12 gap-6">
+            <!-- Left Column -->
             <div class="col-span-12 lg:col-span-4 space-y-6">
               <div class="glass-card p-6 border-l-4 border-blue-500">
-                <h4
-                  class="text-[10px] font-bold uppercase text-slate-500 mb-4 tracking-widest"
-                >
-                  Evidence Ingestion
-                </h4>
-                <div
-                  class="border-2 border-dashed border-slate-800 rounded-xl p-6 text-center hover:border-blue-500 transition-all cursor-pointer"
-                >
-                  <input
-                    type="file"
-                    id="logFile"
-                    class="hidden"
-                    onchange="updateFileName()"
-                  />
-                  <label for="logFile" class="cursor-pointer">
-                    <i
-                      class="fas fa-cloud-arrow-up text-xl text-slate-600 mb-2 block"
-                    ></i>
-                    <p
-                      id="fileNameDisplay"
-                      class="text-[10px] text-slate-500 font-bold uppercase"
-                    >
-                      Select Log Source
-                    </p>
-                  </label>
+                <h4 class="text-[10px] font-bold uppercase text-slate-500 mb-4 tracking-widest">Evidence Ingestion</h4>
+                <div class="border-2 border-dashed border-slate-800 rounded-xl p-6 text-center hover:border-blue-500 transition-all cursor-pointer">
+                  <input type="file" id="logFile" class="hidden" onchange="updateFileName()" />
+                  <label for="logFile" class="cursor-pointer"><i class="fas fa-cloud-arrow-up text-xl text-slate-600 mb-2 block"></i><p id="fileNameDisplay" class="text-[10px] text-slate-500 font-bold uppercase">Select Log Source</p></label>
                 </div>
-                <button
-                  onclick="analyzeLogs(event)"
-                  class="w-full bg-blue-600 hover:bg-blue-700 py-3 rounded-lg font-bold uppercase text-[10px] tracking-widest transition-all mt-4"
-                >
-                  Analyze stream
-                </button>
+                <button onclick="analyzeLogs(event)" class="w-full bg-blue-600 hover:bg-blue-700 py-3 rounded-lg font-bold uppercase text-[10px] tracking-widest transition-all mt-4">Analyze stream</button>
               </div>
-
-              <div
-                id="signatureCard"
-                class="hidden glass-card p-6 border-l-4 border-amber-500"
-              >
-                <h4
-                  class="text-[10px] font-bold uppercase text-amber-500 mb-4 flex items-center gap-2"
-                >
-                  <i class="fas fa-crosshairs"></i> Tactical Anomaly Signature
-                </h4>
-                <div
-                  id="tacticalReasoning"
-                  class="signature-box text-[10px] text-slate-300 leading-relaxed font-mono"
-                ></div>
-              </div>
+              <div id="signatureCard" class="hidden glass-card p-6 border-l-4 border-amber-500"><h4 class="text-[10px] font-bold uppercase text-amber-500 mb-4 flex items-center gap-2"><i class="fas fa-crosshairs"></i> Tactical Anomaly Signature</h4><div id="tacticalReasoning" class="signature-box text-[10px] text-slate-300 leading-relaxed font-mono"></div></div>
             </div>
 
+            <!-- Right Column - Chart -->
             <div class="col-span-12 lg:col-span-8">
               <div class="glass-card p-6 min-h-[500px]">
-    <div class="flex justify-between items-center mb-6">
-        <h4 class="text-[10px] font-bold uppercase text-slate-500 tracking-widest">
-            Integrity Delta Visualization
-        </h4>
-        <div class="flex gap-2">
-            <button onclick="exportChartAsPNG()" class="text-[9px] bg-blue-600/20 hover:bg-blue-600/40 text-blue-400 px-3 py-1.5 rounded-lg transition-all flex items-center gap-1.5 font-bold uppercase tracking-wider">
-                <i class="fas fa-file-image text-xs"></i> PNG
-            </button>
-            <button onclick="exportChartAsJPG()" class="text-[9px] bg-emerald-600/20 hover:bg-emerald-600/40 text-emerald-400 px-3 py-1.5 rounded-lg transition-all flex items-center gap-1.5 font-bold uppercase tracking-wider">
-                <i class="fas fa-camera text-xs"></i> JPG
-            </button>
+                <div class="flex justify-between items-center mb-6">
+                  <h4 class="text-[10px] font-bold uppercase text-slate-500 tracking-widest">Integrity Delta Visualization</h4>
+                  <div class="flex gap-2">
+                    <button onclick="exportChartAsPNG()" class="text-[9px] bg-blue-600/20 hover:bg-blue-600/40 text-blue-400 px-3 py-1.5 rounded-lg transition-all flex items-center gap-1.5 font-bold uppercase tracking-wider"><i class="fas fa-file-image text-xs"></i> PNG</button>
+                    <button onclick="exportChartAsJPG()" class="text-[9px] bg-emerald-600/20 hover:bg-emerald-600/40 text-emerald-400 px-3 py-1.5 rounded-lg transition-all flex items-center gap-1.5 font-bold uppercase tracking-wider"><i class="fas fa-camera text-xs"></i> JPG</button>
+                  </div>
+                </div>
+                <div class="h-[400px] w-full"><canvas id="timelineChart"></canvas></div>
+              </div>
+            </div>
+          </div>
         </div>
-    </div>
-    <div class="h-[400px] w-full">
-        <canvas id="timelineChart"></canvas>
-    </div>
-</div>
-        <div
-          id="view-registry"
-          class="tab-view hidden glass-card overflow-hidden"
-        >
-          <div
-            class="p-6 border-b border-white/5 bg-slate-900/20 flex justify-between items-center"
-          >
-            <div class="flex items-center gap-4">
-              <h4 class="text-xs font-bold uppercase text-slate-400">
-                Incident Registry
-              </h4>
-              <select
-                id="durationSorter"
-                onchange="handleSortChange(this.value)"
-                class="bg-slate-950 border border-white/10 text-[10px] text-blue-400 font-bold uppercase py-1 px-3 rounded-lg outline-none focus:border-blue-500 transition-all cursor-pointer"
-              >
+
+        <!-- REGISTRY TAB -->
+        <div id="view-registry" class="tab-view hidden glass-card overflow-hidden">
+          <div class="p-6 border-b border-white/5 bg-slate-900/20 flex justify-between items-center flex-wrap gap-3">
+            <div class="flex items-center gap-4 flex-wrap">
+              <h4 class="text-xs font-bold uppercase text-slate-400">Incident Registry</h4>
+              <select id="durationSorter" onchange="handleSortChange(this.value)" class="bg-slate-950 border border-white/10 text-[10px] text-blue-400 font-bold uppercase py-1 px-3 rounded-lg outline-none focus:border-blue-500 transition-all cursor-pointer">
                 <option id="sortPlaceholder" value="none">Sort By</option>
                 <option value="high">Longest Gaps First (Critical)</option>
                 <option value="low">Shortest Gaps First (Minor)</option>
               </select>
             </div>
-            <span
-              id="flag-count"
-              class="text-[10px] bg-blue-600 px-3 py-1 rounded-full text-white font-black"
-              >0 Flagged</span
-            >
+            <!-- SEARCH INPUT -->
+            <div class="flex items-center gap-2">
+              <i class="fas fa-search text-slate-500 text-xs"></i>
+              <input type="text" id="searchInput" placeholder="Search by time or duration..." onkeyup="filterRegistry()" class="bg-slate-950 border border-white/10 text-xs text-slate-300 px-3 py-1.5 rounded-lg outline-none focus:border-blue-500 transition-all w-64">
+            </div>
+            <span id="flag-count" class="text-[10px] bg-blue-600 px-3 py-1 rounded-full text-white font-black">0 Flagged</span>
           </div>
-
           <div class="max-h-[600px] overflow-y-auto custom-scroll">
             <table class="w-full text-left" id="incidentTable">
               <thead class="sticky top-0 bg-slate-900 border-b border-white/5">
@@ -303,58 +133,22 @@
                   <th class="p-6 text-center">Duration</th>
                   <th class="p-6">Analysis Signature</th>
                   <th class="p-6 text-right">Triage</th>
-                </tr>
+                </td>
               </thead>
-              <tbody
-                id="incidentBody"
-                class="text-[11px] text-slate-400"
-              ></tbody>
+              <tbody id="incidentBody" class="text-[11px] text-slate-400"></tbody>
             </table>
           </div>
         </div>
 
-        <div
-          id="view-compliance"
-          class="tab-view hidden flex flex-col items-center justify-center p-6"
-        >
+        <!-- COMPLIANCE TAB -->
+        <div id="view-compliance" class="tab-view hidden flex flex-col items-center justify-center p-6">
           <div data-aos="zoom-in" class="text-center max-w-2xl">
-            <div
-              class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 text-[10px] font-bold tracking-[0.2em] mb-8"
-            >
-              <i class="fas fa-file-shield animate-pulse"></i> LEGAL COMPLIANCE
-              MODULE
-            </div>
-
-            <h2
-              class="text-4xl md:text-6xl font-black mb-6 tracking-tighter text-white uppercase leading-none"
-            >
-              Secure The <br /><span class="text-blue-500 italic glow-text"
-                >Chain of Custody.</span
-              >
-            </h2>
-
-            <p
-              class="text-sm text-slate-400 mb-12 leading-relaxed max-w-lg mx-auto font-light"
-            >
-              Generate cryptographically signed evidence packages. These reports
-              anchor your forensic findings to a unique SHA-256 hash for legal
-              admissibility.
-            </p>
-
+            <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 text-[10px] font-bold tracking-[0.2em] mb-8"><i class="fas fa-file-shield animate-pulse"></i> LEGAL COMPLIANCE MODULE</div>
+            <h2 class="text-4xl md:text-6xl font-black mb-6 tracking-tighter text-white uppercase leading-none">Secure The <br /><span class="text-blue-500 italic glow-text">Chain of Custody.</span></h2>
+            <p class="text-sm text-slate-400 mb-12 leading-relaxed max-w-lg mx-auto font-light">Generate cryptographically signed evidence packages. These reports anchor your forensic findings to a unique SHA-256 hash for legal admissibility.</p>
             <div class="flex flex-col md:flex-row gap-6 justify-center">
-              <button
-                onclick="exportForensicJSON()"
-                class="px-10 py-4 bg-blue-600 hover:bg-blue-500 text-white font-black uppercase text-xs rounded shadow-[0_0_30px_rgba(37,99,235,0.3)] transition-all transform hover:scale-105 btn-glow"
-              >
-                Download Signed JSON
-              </button>
-              <button
-                onclick="exportRegistryCSV()"
-                class="px-10 py-4 glass bg-white/5 text-white font-black uppercase text-xs rounded transition-all flex items-center justify-center gap-2 border border-white/10 hover:border-white/20"
-              >
-                Export Registry CSV
-                <i class="fas fa-file-csv text-blue-500"></i>
-              </button>
+              <button onclick="exportForensicJSON()" class="px-10 py-4 bg-blue-600 hover:bg-blue-500 text-white font-black uppercase text-xs rounded shadow-[0_0_30px_rgba(37,99,235,0.3)] transition-all transform hover:scale-105 btn-glow">Download Signed JSON</button>
+              <button onclick="exportRegistryCSV()" class="px-10 py-4 glass bg-white/5 text-white font-black uppercase text-xs rounded transition-all flex items-center justify-center gap-2 border border-white/10 hover:border-white/20">Export Registry CSV <i class="fas fa-file-csv text-blue-500"></i></button>
             </div>
           </div>
         </div>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -468,3 +468,39 @@ function exportRegistryCSV() {
   a.click();
   showToast("Registry CSV Downloaded");
 }
+
+// Export chart as PNG
+function exportChartAsPNG() {
+    if (!chart) {
+        showToast("No chart data available");
+        return;
+    }
+    const canvas = chart.canvas;
+    const link = document.createElement('a');
+    link.download = `chart_export_${Date.now()}.png`;
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+    showToast("Chart exported as PNG");
+}
+
+// Export chart as JPG
+function exportChartAsJPG() {
+    if (!chart) {
+        showToast("No chart data available");
+        return;
+    }
+    const canvas = chart.canvas;
+    // Create white background for JPG (JPG doesn't support transparency)
+    const tempCanvas = document.createElement('canvas');
+    tempCanvas.width = canvas.width;
+    tempCanvas.height = canvas.height;
+    const tempCtx = tempCanvas.getContext('2d');
+    tempCtx.fillStyle = 'white';
+    tempCtx.fillRect(0, 0, tempCanvas.width, tempCanvas.height);
+    tempCtx.drawImage(canvas, 0, 0);
+    const link = document.createElement('a');
+    link.download = `chart_export_${Date.now()}.jpg`;
+    link.href = tempCanvas.toDataURL('image/jpeg', 0.9);
+    link.click();
+    showToast("Chart exported as JPG");
+}

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -504,3 +504,24 @@ function exportChartAsJPG() {
     link.click();
     showToast("Chart exported as JPG");
 }
+
+// Search/Filter functionality for Incident Registry
+function filterRegistry() {
+    const searchTerm = document.getElementById("searchInput").value.toLowerCase();
+    if (!lastScanResults || !lastScanResults.incidents) return;
+    
+    let filteredIncidents = lastScanResults.incidents;
+    
+    if (searchTerm) {
+        filteredIncidents = lastScanResults.incidents.filter(inc => {
+            // Search by timestamp (start or end time)
+            const timeMatch = inc.start.toLowerCase().includes(searchTerm) || 
+                              inc.end.toLowerCase().includes(searchTerm);
+            // Search by duration
+            const durationMatch = inc.duration.toString().includes(searchTerm);
+            return timeMatch || durationMatch;
+        });
+    }
+    
+    updateRegistryTable(filteredIncidents);
+}


### PR DESCRIPTION
 Changes
- Added **PNG Export** button in the dashboard chart section
- Added **JPG Export** button in the dashboard chart section
- Implemented `exportChartAsPNG()` function using Chart.js canvas `toDataURL()`
- Implemented `exportChartAsJPG()` function with white background for proper rendering

<img width="1910" height="920" alt="Screenshot 2026-04-19 103655" src="https://github.com/user-attachments/assets/a5bb8f8f-1890-49d0-97cc-95163a320946" />
<img width="1908" height="1022" alt="Screenshot 2026-04-19 103714" src="https://github.com/user-attachments/assets/56712a45-e28e-44c9-b872-0db19e646207" />


 Export Buttons in Dashboard
[Screenshot showing PNG and JPG buttons in the chart section]

 Downloaded Files
[Screenshot showing downloaded PNG and JPG files]

How to Test
1. Load the dashboard with any incident data
2. Click the **PNG** button → downloads chart as PNG
3. Click the **JPG** button → downloads chart as JPG


## Checklist
- [x] PNG export working
- [x] JPG export working
- [x] Buttons visible in dashboard
- [x] No existing functionality broken