### PR TITLE
Add support for 12-hour and 24-hour time format toggle

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -8,26 +8,34 @@ TIMESTAMP_PATTERN = r'(\d{4}[-/.]\d{2}[-/.]\d{2}[T ]\d{2}:\d{2}:\d{2})'
 def parse_any_date(date_str):
     """Attempts to parse different date formats found in logs."""
     formats = [
-        '%Y-%m-%dT%H:%M:%S', # ISO format (2024-01-01T09:00:00)
+        '%Y-%m-%dT%H:%M:%S', # ISO format
         '%Y-%m-%d %H:%M:%S', # Standard format
         '%Y/%m/%d %H:%M:%S', # Alternate slashes
         '%Y.%m.%d %H:%M:%S'  # Dot separators
     ]
     for fmt in formats:
         try:
-            # We strip the string to 19 characters to ignore potential trailing ms
             return datetime.strptime(date_str[:19], fmt)
         except ValueError:
             continue
     return None
 
-def analyze_logs(file_path, threshold_seconds=60):
+
+def analyze_logs(file_path, threshold_seconds=60, use_24_hour=True):
     """
     Analyzes log file for temporal gaps and categorizes anomalies.
+    Allows toggling between 12-hour and 24-hour time formats.
     """
+
+    #  STEP 1: Decide time format based on toggle
+    if use_24_hour:
+        time_format = '%Y-%m-%d %H:%M:%S'
+    else:
+        time_format = '%Y-%m-%d %I:%M:%S %p'
+
     incidents = []
     last_time = None
-    
+
     # Ensure threshold is an integer
     try:
         threshold_seconds = int(threshold_seconds)
@@ -39,10 +47,10 @@ def analyze_logs(file_path, threshold_seconds=60):
             match = re.search(TIMESTAMP_PATTERN, line)
             if match:
                 current_time = parse_any_date(match.group(1))
-                
+
                 if current_time and last_time:
                     gap = (current_time - last_time).total_seconds()
-                    
+
                     if gap > threshold_seconds:
                         # --- DYNAMIC ANOMALY CATEGORIZATION ---
                         if gap > 3600:
@@ -58,20 +66,21 @@ def analyze_logs(file_path, threshold_seconds=60):
                             reason = "Minor Sequential Lag"
                             severity = "WARNING"
 
+                        # STEP 2: Use dynamic format
                         incidents.append({
-                            "start": last_time.strftime('%Y-%m-%d %H:%M:%S'),
-                            "end": current_time.strftime('%Y-%m-%d %H:%M:%S'),
+                            "start": last_time.strftime(time_format),
+                            "end": current_time.strftime(time_format),
                             "duration": int(gap),
                             "severity": severity,
                             "details": reason
                         })
-                
+
                 if current_time:
                     last_time = current_time
 
-    # Calculate Integrity Score (starts at 100%, -5% per gap)
+    # Calculate Integrity Score
     score = max(0, 100.00 - (len(incidents) * 5.0))
-    
+
     return {
         "total_gaps": len(incidents),
         "integrity_score": round(score, 2),


### PR DESCRIPTION
This PR introduces support for toggling timestamps between 12-hour and 24-hour formats.

Changes made:
- Added `use_24_hour` parameter to analyze_logs function
- Implemented dynamic time formatting using strftime
- Default behavior remains 24-hour format for backward compatibility

Closes #10