### PR TITLE
Fix: Dynamic copyright year in footerremove venv from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-
-.env
+venv/
 __pycache__/
+*.pyc
+.env
+uploads/
+users.json

--- a/html/index.html
+++ b/html/index.html
@@ -561,9 +561,9 @@
       <div
         class="max-w-7xl mx-auto px-6 pt-8 border-t border-white/5 flex flex-col md:flex-row justify-between items-center gap-6"
       >
-        <p class="text-slate-600 text-[10px] uppercase tracking-[0.4em]">
-          © 2026 EVIDENCE PROTECTOR v2.0 | <a href="javascript:void(0)" onclick="showTOS()" class="hover:text-blue-500 transition-colors">Terms of Service</a>
-        </p>
+       <p class="text-slate-600 text-[10px] uppercase tracking-[0.4em]">
+  © <span id="current-year"></span> EVIDENCE PROTECTOR v2.0 | <a href="javascript:void(0)" onclick="showTOS()" class="hover:text-blue-500 transition-colors">Terms of Service</a>
+</p>
 
         <div class="flex gap-8 text-slate-500 text-lg">
           <a href="#" class="hover:text-blue-500 transition-colors"
@@ -820,5 +820,9 @@
 
     <script src="../js/theme.js"></script>
     <script src="../js/index.js"></script>
+    <script>
+  // Dynamic Copyright Year
+  document.getElementById('current-year').textContent = new Date().getFullYear();
+</script>
   </body>
 </html>


### PR DESCRIPTION
- Replaced static footer year with dynamic JavaScript-based year
- Ensures footer always displays the current year automatically
- Improves maintainability and removes need for manual updates

Closes #2