### PR TITLE
feat: add threshold input with tooltip explanation

### DIFF
--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -286,6 +286,26 @@
                     </p>
                   </label>
                 </div>
+                <div class="mt-4">
+                  <label class="text-[10px] text-slate-400 font-bold uppercase">
+                    Threshold
+                    <span 
+                      class="ml-2 text-blue-400 cursor-pointer"
+                      title="Maximum allowed seconds between log entries before flagging a gap."
+                    >
+                      ❓
+                    </span>
+                  </label>
+
+                  <input 
+                    type="number" 
+                    id="thresholdInput"
+                    value="60"
+                    class="w-full mt-2 px-3 py-2 bg-slate-900 border border-white/10 rounded text-white text-sm"
+                  />
+                </div> 
+
+                                
                 <button
                   onclick="analyzeLogs(event)"
                   class="w-full bg-blue-600 hover:bg-blue-700 py-3 rounded-lg font-bold uppercase text-[10px] tracking-widest mt-4"

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -81,7 +81,8 @@ async function analyzeLogs(event) {
 
   const formData = new FormData();
   formData.append("file", file);
-  formData.append("threshold", 60);
+  const thresholdValue = document.getElementById("thresholdInput")?.value || 60;
+  formData.append("threshold", thresholdValue);
 
   try {
     const token = localStorage.getItem("access_token");


### PR DESCRIPTION
Closes #33

## Summary

Added a user-facing input for "Threshold" along with a tooltip explanation to improve usability and clarity.

## Problem

The threshold parameter was previously hardcoded in the frontend and not visible to users. This made it difficult to understand or adjust how gaps between log entries were detected.

## Changes

* Added a numeric input field for "Threshold" in the dashboard UI
* Added a hoverable tooltip (❓) explaining its purpose:
  "Maximum allowed seconds between log entries before flagging a gap"
* Updated JavaScript logic to dynamically send the user-defined threshold value instead of a hardcoded value

## Result

* Users can now control the threshold value
* Improved user experience and transparency
* Better alignment between frontend UI and backend logic

## Testing

* Verified UI renders correctly without layout issues
* Confirmed tooltip appears on hover
* Ensured selected threshold value is correctly sent in API request
