### PR TITLE
feat(ui): restrict greeting panel to dashboard tab only

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -501,6 +501,12 @@ function switchTab(tabId) {
     .forEach((v) => v.classList.add("hidden"));
   document.getElementById(`view-${tabId}`)?.classList.remove("hidden");
 
+  // ISSUE #72: Hide greeting panel on non-dashboard tabs
+  const greetingPanel = document.querySelector('.glass-card.p-6.border-l-4.border-blue-500.flex.items-center.justify-between');
+  if (greetingPanel) {
+    greetingPanel.style.display = tabId === 'dashboard' ? 'flex' : 'none';
+  }
+
   if (tabId === "history") renderCaseHistory();
   if (tabId === "dashboard" && lastScanResults)
     setTimeout(() => updateChart(lastScanResults.incidents), 50);


### PR DESCRIPTION
## 📋 Summary
Restricts the greeting panel ("Good Morning/Afternoon/Evening, Operator") to only appear on the Dashboard tab.

## Current Behavior
The greeting panel remains visible on ALL tabs (Dashboard, Registry, Case History, Export Center).

## Expected Behavior (After Fix)
- **Dashboard Tab** → Greeting panel VISIBLE ✅
- **Registry Tab** → Greeting panel HIDDEN ❌
- **Case History Tab** → Greeting panel HIDDEN ❌
- **Export Center Tab** → Greeting panel HIDDEN ❌

## ✨ Changes Made
- Modified `switchTab()` function in `dashboard.js`
- Added conditional logic to show/hide greeting panel based on active tab

## 📁 Files Changed
- `js/dashboard.js`

<img width="1919" height="975" alt="Screenshot 2026-04-24 105447" src="https://github.com/user-attachments/assets/e3cb4ae8-0f65-47c2-be72-9930b9c49403" />
<img width="1919" height="966" alt="Screenshot 2026-04-24 105501" src="https://github.com/user-attachments/assets/6136ca32-6e07-4542-b4ce-53e596ea0f8f" />
