### PR TITLE
Modal Overlay for Settings

### DIFF
--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -380,22 +380,22 @@
                     </p>
                   </label>
                 </div>
-                <div class="mt-4">
-                  <label class="text-[10px] text-slate-400 font-bold uppercase">
-                    Threshold
-                    <span
-                      class="ml-2 text-blue-400 cursor-pointer"
-                      title="Maximum allowed seconds between log entries before flagging a gap."
-                    >
-                      ❓
-                    </span>
-                  </label>
-                  <input
-                    type="number"
-                    id="thresholdInput"
-                    value="60"
-                    class="w-full mt-2 px-3 py-2 bg-slate-900 border border-white/10 rounded text-white text-sm"
-                  />
+                <div class="mt-4 flex items-center justify-between gap-3">
+                  <div>
+                    <p class="text-[10px] text-slate-400 font-bold uppercase">
+                      Analysis Settings
+                    </p>
+                    <p id="settingsSummary" class="text-[9px] text-slate-500 font-mono mt-1">
+                      Threshold: 60s • Types: .log, .txt, .csv
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onclick="openAnalysisSettingsModal()"
+                    class="bg-slate-800 hover:bg-slate-700 px-4 py-2 rounded-lg text-[10px] font-bold uppercase tracking-widest border border-white/10"
+                  >
+                    <i class="fas fa-sliders mr-2"></i> Settings
+                  </button>
                 </div>
                 <div class="flex gap-3 mt-4">
                   <button onclick="analyzeLogs(event)" class="flex-1 bg-blue-600 hover:bg-blue-700 py-3 rounded-lg font-bold uppercase text-[10px] tracking-widest transition-all">
@@ -753,6 +753,90 @@
     </div>
 
     <div
+      id="analysisSettingsModal"
+      class="fixed inset-0 hidden items-center justify-center bg-black/65 backdrop-blur-md z-[300]"
+      onclick="closeAnalysisSettingsModal()"
+    >
+      <div
+        onclick="event.stopPropagation()"
+        class="settings-modal-panel w-[92%] max-w-xl rounded-2xl border border-white/10 bg-slate-900/95 shadow-2xl"
+      >
+        <div class="flex items-center justify-between p-6 border-b border-white/10">
+          <div>
+            <h3 class="text-white text-lg font-black uppercase tracking-wide">Analysis Settings</h3>
+            <p class="text-[9px] text-slate-500 font-bold uppercase tracking-widest mt-1">
+              Configure thresholds and accepted file types
+            </p>
+          </div>
+          <button
+            type="button"
+            onclick="closeAnalysisSettingsModal()"
+            class="text-slate-500 hover:text-red-400 transition-colors"
+            aria-label="Close analysis settings"
+          >
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+
+        <div class="p-6 space-y-6">
+          <div>
+            <label for="thresholdInput" class="text-[10px] text-slate-400 font-bold uppercase tracking-widest">
+              Gap Threshold (seconds)
+            </label>
+            <input
+              type="number"
+              id="thresholdInput"
+              min="1"
+              max="3600"
+              value="60"
+              class="w-full mt-2 px-3 py-2 bg-slate-900 border border-white/10 rounded text-white text-sm"
+            />
+            <p class="text-[9px] text-slate-600 mt-2 font-mono">
+              Larger values reduce sensitivity to short interruptions.
+            </p>
+          </div>
+
+          <div>
+            <p class="text-[10px] text-slate-400 font-bold uppercase tracking-widest mb-3">
+              Allowed File Types
+            </p>
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <label class="settings-type-option flex items-center gap-2 px-3 py-2 rounded-lg border border-white/10 bg-slate-950/50 text-slate-300 text-sm">
+                <input type="checkbox" class="settings-file-type" value=".log" checked />
+                <span class="font-mono">.log</span>
+              </label>
+              <label class="settings-type-option flex items-center gap-2 px-3 py-2 rounded-lg border border-white/10 bg-slate-950/50 text-slate-300 text-sm">
+                <input type="checkbox" class="settings-file-type" value=".txt" checked />
+                <span class="font-mono">.txt</span>
+              </label>
+              <label class="settings-type-option flex items-center gap-2 px-3 py-2 rounded-lg border border-white/10 bg-slate-950/50 text-slate-300 text-sm">
+                <input type="checkbox" class="settings-file-type" value=".csv" checked />
+                <span class="font-mono">.csv</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-6 pt-4 border-t border-white/10 flex justify-end gap-3">
+          <button
+            type="button"
+            onclick="closeAnalysisSettingsModal()"
+            class="px-5 py-2 border border-white/20 text-slate-300 font-bold text-xs uppercase rounded-lg hover:bg-white/10"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onclick="applyAnalysisSettings()"
+            class="px-5 py-2 bg-blue-600 hover:bg-blue-500 text-white font-bold text-xs uppercase rounded-lg"
+          >
+            Save Settings
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
       id="clearVaultModal"
       class="fixed inset-0 hidden items-center justify-center bg-black/60 backdrop-blur-md z-[300]"
       onclick="closeClearVaultModal()"
@@ -820,6 +904,16 @@
             fileInput.addEventListener('change', function(e) {
                 const file = e.target.files[0];
                 if (file) {
+              if (typeof window.isFileAllowedBySettings === 'function' && !window.isFileAllowedBySettings(file)) {
+                previewBtn.disabled = true;
+                previewBtn.classList.add('opacity-50', 'cursor-not-allowed');
+                currentLogContent = null;
+                fileInput.value = '';
+                const fileNameDisplay = document.getElementById('fileNameDisplay');
+                if (fileNameDisplay) fileNameDisplay.innerText = 'Select Log File';
+                return;
+              }
+
                     previewBtn.disabled = false;
                     previewBtn.classList.remove('opacity-50', 'cursor-not-allowed');
                     const reader = new FileReader();

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -8,6 +8,12 @@ let chart = null;
 let lastScanResults = null;
 let flaggedIncidents = new Set();
 const CASES_KEY = "forensic_cases";
+const ANALYSIS_SETTINGS_KEY = "analysis_settings";
+const DEFAULT_ANALYSIS_SETTINGS = {
+  threshold: 60,
+  fileTypes: [".log", ".txt", ".csv"],
+};
+let analysisSettings = { ...DEFAULT_ANALYSIS_SETTINGS };
 
 // ─── INITIALIZATION ──────────────────────────────────────────────────────────
 window.addEventListener("DOMContentLoaded", () => {
@@ -32,6 +38,8 @@ window.addEventListener("DOMContentLoaded", () => {
   }
 
   // 3. UI Bootstrap
+  loadAnalysisSettings();
+  applyAnalysisSettingsToUI();
   updateGreeting();
   updateCaseBadge();
   loadLastSession();
@@ -79,13 +87,20 @@ async function analyzeLogs(event) {
     return showToast("Critical: No source file selected");
   }
 
+  if (!isFileAllowedBySettings(file)) {
+    return showToast(
+      `File type not allowed: ${getFileExtension(file.name) || "unknown"}`,
+    );
+  }
+
   const overlay = document.getElementById("scanOverlay");
   const statusText = document.getElementById("loaderStatus");
   overlay.classList.remove("hidden");
 
   const formData = new FormData();
   formData.append("file", file);
-  const thresholdValue = document.getElementById("thresholdInput")?.value || 60;
+  const thresholdValue =
+    document.getElementById("thresholdInput")?.value || analysisSettings.threshold;
   formData.append("threshold", thresholdValue);
 
   try {
@@ -118,6 +133,120 @@ async function analyzeLogs(event) {
     showToast("Backend Link Error");
   } finally {
     overlay.classList.add("hidden");
+  }
+}
+
+function loadAnalysisSettings() {
+  const saved = localStorage.getItem(ANALYSIS_SETTINGS_KEY);
+  if (!saved) return;
+
+  try {
+    const parsed = JSON.parse(saved);
+    const threshold = Number.parseInt(parsed?.threshold, 10);
+    const fileTypes = Array.isArray(parsed?.fileTypes)
+      ? parsed.fileTypes.filter((type) =>
+          DEFAULT_ANALYSIS_SETTINGS.fileTypes.includes(type),
+        )
+      : [];
+
+    analysisSettings = {
+      threshold:
+        Number.isFinite(threshold) && threshold > 0
+          ? threshold
+          : DEFAULT_ANALYSIS_SETTINGS.threshold,
+      fileTypes:
+        fileTypes.length > 0 ? fileTypes : [...DEFAULT_ANALYSIS_SETTINGS.fileTypes],
+    };
+  } catch (_) {
+    analysisSettings = { ...DEFAULT_ANALYSIS_SETTINGS };
+  }
+}
+
+function saveAnalysisSettings() {
+  localStorage.setItem(ANALYSIS_SETTINGS_KEY, JSON.stringify(analysisSettings));
+}
+
+function applyAnalysisSettingsToUI() {
+  const thresholdInput = document.getElementById("thresholdInput");
+  if (thresholdInput) thresholdInput.value = String(analysisSettings.threshold);
+
+  const fileInput = document.getElementById("logFile");
+  if (fileInput) {
+    fileInput.setAttribute("accept", analysisSettings.fileTypes.join(","));
+  }
+
+  const checkboxes = document.querySelectorAll(".settings-file-type");
+  checkboxes.forEach((checkbox) => {
+    checkbox.checked = analysisSettings.fileTypes.includes(checkbox.value);
+  });
+
+  const summaryEl = document.getElementById("settingsSummary");
+  if (summaryEl) {
+    summaryEl.innerText = `Threshold: ${analysisSettings.threshold}s • Types: ${analysisSettings.fileTypes.join(", ")}`;
+  }
+}
+
+function getFileExtension(fileName) {
+  if (!fileName || !fileName.includes(".")) return "";
+  const dotIndex = fileName.lastIndexOf(".");
+  return fileName.slice(dotIndex).toLowerCase();
+}
+
+function isFileAllowedBySettings(file) {
+  const ext = getFileExtension(file?.name);
+  return analysisSettings.fileTypes.includes(ext);
+}
+
+function openAnalysisSettingsModal() {
+  applyAnalysisSettingsToUI();
+  const modal = document.getElementById("analysisSettingsModal");
+  if (!modal) return;
+  modal.classList.remove("hidden");
+  modal.classList.add("flex");
+}
+
+function closeAnalysisSettingsModal() {
+  const modal = document.getElementById("analysisSettingsModal");
+  if (!modal) return;
+  modal.classList.add("hidden");
+  modal.classList.remove("flex");
+}
+
+function applyAnalysisSettings() {
+  const thresholdInput = document.getElementById("thresholdInput");
+  const parsedThreshold = Number.parseInt(thresholdInput?.value, 10);
+  const threshold = Number.isFinite(parsedThreshold)
+    ? Math.min(3600, Math.max(1, parsedThreshold))
+    : DEFAULT_ANALYSIS_SETTINGS.threshold;
+
+  const selectedFileTypes = Array.from(
+    document.querySelectorAll(".settings-file-type:checked"),
+  ).map((input) => input.value);
+
+  if (selectedFileTypes.length === 0) {
+    showToast("Select at least one file type");
+    return;
+  }
+
+  analysisSettings = {
+    threshold,
+    fileTypes: selectedFileTypes,
+  };
+
+  saveAnalysisSettings();
+  applyAnalysisSettingsToUI();
+  closeAnalysisSettingsModal();
+  showToast("Analysis settings updated");
+
+  const fileInput = document.getElementById("logFile");
+  const currentFile = fileInput?.files?.[0] || null;
+  if (currentFile && !isFileAllowedBySettings(currentFile)) {
+    fileInput.value = "";
+    const fileNameDisplay = document.getElementById("fileNameDisplay");
+    if (fileNameDisplay) fileNameDisplay.innerText = "Select Log File";
+    const previewBtn = document.getElementById("previewBtn");
+    if (previewBtn) previewBtn.disabled = true;
+    showToast(`Current file removed (${getFileExtension(currentFile.name)} blocked)`);
   }
 }
 
@@ -542,18 +671,40 @@ function initDropZone() {
   const dropArea = document.getElementById("dropArea");
   const fileInput = document.getElementById("logFile");
   if (!dropArea || !fileInput) return;
+
   fileInput.addEventListener("change", () => {
-    if (fileInput.files.length > 0)
-      document.getElementById("fileNameDisplay").innerText =
-        fileInput.files[0].name;
+    if (fileInput.files.length === 0) return;
+
+    const selectedFile = fileInput.files[0];
+    if (!isFileAllowedBySettings(selectedFile)) {
+      fileInput.value = "";
+      document.getElementById("fileNameDisplay").innerText = "Select Log File";
+      showToast(
+        `Unsupported type: ${getFileExtension(selectedFile.name) || "unknown"}`,
+      );
+      return;
+    }
+
+    document.getElementById("fileNameDisplay").innerText = selectedFile.name;
   });
+
   dropArea.addEventListener("drop", (e) => {
     e.preventDefault();
-    if (e.dataTransfer.files.length > 0) {
-      fileInput.files = e.dataTransfer.files;
-      document.getElementById("fileNameDisplay").innerText =
-        fileInput.files[0].name;
+
+    const droppedFile = e.dataTransfer.files?.[0];
+    if (!droppedFile) return;
+
+    if (!isFileAllowedBySettings(droppedFile)) {
+      showToast(
+        `Unsupported type: ${getFileExtension(droppedFile.name) || "unknown"}`,
+      );
+      return;
     }
+
+    const transfer = new DataTransfer();
+    transfer.items.add(droppedFile);
+    fileInput.files = transfer.files;
+    document.getElementById("fileNameDisplay").innerText = droppedFile.name;
   });
 }
 

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -628,6 +628,37 @@ html[data-theme="light"] #view-compliance h2 {
   letter-spacing: -0.03em !important;
 }
 
+/* ── Analysis Settings Modal ─────────────────────────────────────────────── */
+.settings-modal-panel {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+}
+
+.settings-type-option {
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.settings-type-option:hover {
+  border-color: var(--border-hover);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+html[data-theme="light"] .settings-modal-panel {
+  background: #ffffff !important;
+  border: 1px solid #dde3ed !important;
+  box-shadow: 0 24px 64px rgba(17, 24, 39, 0.2) !important;
+}
+
+html[data-theme="light"] .settings-type-option {
+  background: #f8fafc !important;
+  border-color: #dde3ed !important;
+}
+
+html[data-theme="light"] .settings-type-option:hover {
+  background: #eff6ff !important;
+  border-color: #2563eb !important;
+}
+
 /* ═══════════════════════════════════════════════════════════════
    TOS MODAL — CLEAN FIX (Dark + Light fully handled)
    ═══════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
Implemented and verified: the dashboard now uses a pop-up Analysis Settings modal for threshold and file type filters, instead of showing threshold controls in the main Evidence Ingestion area.

What changed
- Moved settings out of the main dashboard card and replaced with:
  - Settings button
  - compact settings summary text
- Added Analysis Settings modal overlay with:
  - threshold input
  - file type filters (.log, .txt, .csv)
  - Cancel and Save actions
- Added settings persistence in localStorage and UI sync on load
- Wired file type validation for:
  - file picker selection
  - drag and drop
  - analyze action
- Updated modal styling for dark/light theme consistency

Updated files
- dashboard.html
- dashboard.js
- dashboard.css

Local verification status
- Verified in browser at:
  - http://127.0.0.1:5500/html/index.html
  - after login, dashboard at http://127.0.0.1:5500/html/dashboard.html
- Confirmed modal opens from Settings button and saves correctly.
- Confirmed summary updates after save (example verified: Threshold 120s, Types .log and .csv).



closes #86


