### PR TITLE
fix: connect SSE /analyze-process to real analyze_logs with progress_callback

### DIFF
--- a/main.py
+++ b/main.py
@@ -280,18 +280,55 @@ async def upload_log(
     finally:
         if os.path.exists(temp_path):
             os.remove(temp_path)
+
 @app.get("/analyze-process")
-async def analyze_process():
+async def analyze_process(
+    file_path: str,
+    threshold: int = 60,
+    current_user: str = Depends(get_current_user),
+):
+    """
+    SSE endpoint streaming real analysis progress from analyze_logs().
+    Fixes hardcoded progress messages by wiring progress_callback to the stream.
+    """
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def progress_callback(percent: int, message: str):
+        queue.put_nowait({"percent": percent, "message": message})
+
     async def event_generator():
-        yield f"data: {json.dumps({'percent':10, 'message':'Starting analysis...'})}\n\n"
-        await asyncio.sleep(0.5)
-        yield f"data:{json.dumps({'percent':50, 'message': 'analyzing logs..'})}\n\n"
-        await asyncio.sleep(0.5)
-        yield f"data:{json.dumps({'percent':100, 'message': 'Analysis completed.'})}\n\n"
+        loop = asyncio.get_event_loop()
+        analysis_task = loop.run_in_executor(
+            None,
+            lambda: analyze_logs(
+                file_path,
+                threshold_seconds=threshold,
+                progress_callback=progress_callback,
+            ),
+        )
+
+        while True:
+            try:
+                event = await asyncio.wait_for(queue.get(), timeout=0.5)
+                yield f"data: {json.dumps(event)}\n\n"
+                if event.get("percent") == 100:
+                    break
+            except asyncio.TimeoutError:
+                if analysis_task.done():
+                    break
+
+        try:
+            result = await analysis_task
+            yield f"data: {json.dumps({'percent': 100, 'message': 'Analysis completed.', 'result': result})}\n\n"
+        except Exception as e:
+            logger.error("SSE analysis error: %s", e)
+            yield f"data: {json.dumps({'percent': 100, 'message': f'Error: {str(e)}'})}\n\n"
+
     return StreamingResponse(
-            event_generator(),
-            media_type="text/event-stream"
-)
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
Fixes #101

## Problem
The /analyze-process SSE endpoint returned hardcoded progress 
messages that never reflected actual analysis state. The 
progress_callback parameter in analyze_logs() existed but 
was never connected to the SSE stream.

## Solution
- Wired progress_callback from logic.py to an asyncio.Queue
- analyze_logs() runs in a thread executor to avoid blocking 
  the event loop
- Real progress events stream as they occur (10%, 60%, 80%, 100%)
- Final result included in the last SSE event
- Added Cache-Control and X-Accel-Buffering headers for 
  proper SSE behaviour
- Endpoint now requires JWT authentication

## Testing
Tested with a sample log file containing 3 time gaps:

data: {"percent": 10, "message": "step1:deciding time format.."}
data: {"percent": 60, "message": "step 2 :detecting gaps in logs.."}
data: {"percent": 80, "message": "step 3 : calculating intergrity score.."}
data: {"percent": 100, "message": "Analysis completed.", "result": {"total_gaps": 3, "integrity_score": 37.1}}

## Changes
- main.py: replaced hardcoded SSE handler with real progress_callback wiring