### PR TITLE
fix: CORS configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,10 +63,10 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["http://localhost:8000", "http://127.0.0.1:8000"],
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # ─── EXCEPTION HANDLERS ──────────────────────────────────────────────────────


### PR DESCRIPTION

Current CORS config:
- `allow_origins`: `["http://localhost:8000", "http://127.0.0.1:8000"]`
- `allow_credentials`: `True`
- `allow_methods`: `["GET", "POST"]`
- `allow_headers`: `["Authorization", "Content-Type"]`

This removes the insecure wildcard + credentials combination and enforces a restricted CORS policy.

closes #103