### PR TITLE
Fix: Incomplete logout logic and BFCache session restoration vulnerability

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -17,6 +17,13 @@ const DEFAULT_ANALYSIS_SETTINGS = {
 };
 let analysisSettings = { ...DEFAULT_ANALYSIS_SETTINGS };
 
+// ─── BFCache Protection ───────────────────────────────────────────────────────
+window.addEventListener("pageshow", (event) => {
+  if (event.persisted && !localStorage.getItem("access_token")) {
+    window.location.replace("index.html");
+  }
+});
+
 // ─── INITIALIZATION ──────────────────────────────────────────────────────────
 window.addEventListener("DOMContentLoaded", () => {
   // 1. Unified Authentication Check
@@ -24,7 +31,7 @@ window.addEventListener("DOMContentLoaded", () => {
     !!localStorage.getItem("access_token") ||
     !!sessionStorage.getItem("isLoggedIn");
   if (!hasAuth) {
-    window.location.href = "index.html";
+    window.location.replace("index.html");
     return;
   }
 
@@ -814,9 +821,18 @@ function updateGreeting() {
 }
 
 function logout() {
+  // Clear auth state AND all sensitive forensic data
   localStorage.removeItem("access_token");
+  localStorage.removeItem("last_forensic_scan");
+  localStorage.removeItem("last_scan_metadata");
+  localStorage.removeItem("forensic_cases");
+  localStorage.removeItem("flagged_items");
+  localStorage.removeItem("analysis_settings");
+  
   sessionStorage.clear();
-  window.location.href = "index.html";
+  
+  // Use .replace() to prevent the user from using the browser's Back button to return to the dashboard
+  window.location.replace("index.html");
 }
 
 function showTOS() {


### PR DESCRIPTION
## Description
This PR addresses the security vulnerability where users remained "logged in" and sensitive data was left in the browser's memory after logging out of the dashboard.

## Changes Made

1. Prevented BFCache Restoration: Replaced window.location.href with window.location.replace("index.html") to remove the dashboard from the browser's session history, stopping users from using the "Back" button to return to an authenticated state.
2. Added Active pageshow Validation: Added an event listener that actively validates the access_token even if the dashboard is restored from the browser's memory, ensuring unauthorized access is immediately ejected.
3. Complete State Purge: Updated the logout() function to thoroughly clear all sensitive forensic data from localStorage (e.g., forensic_cases, last_scan_metadata, flagged_items) rather than just the access token.

## Testing & Verification

1. I have successfully tested these changes by running both the FastAPI backend and frontend locally.
2. Verified that clicking "Logout" fully strips all forensic data and tokens from local storage.
3. Verified that attempting to use the browser's "Back" button after logging out successfully blocks access and ejects the session.