### PR TITLE
feat: implement Evidence Package (ZIP) export 

### DIFF
--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -298,7 +298,10 @@
         <div id="view-compliance" class="tab-view hidden flex flex-col items-center justify-center p-20 text-center">
           <h2 class="text-4xl font-black text-white uppercase mb-4 tracking-tighter">Export Center</h2>
           <p class="text-slate-400 mb-8 max-w-lg">Generate signed evidence packages for legal admissibility.</p>
-          <div class="flex gap-4">
+          <div class="flex flex-wrap justify-center gap-4">
+            <button onclick="exportEvidenceZIP()" class="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-black uppercase text-xs rounded transition-all">
+              <i class="fas fa-file-zipper mr-2"></i> Export Evidence Package (ZIP)
+            </button>
             <button onclick="exportForensicJSON()" class="px-8 py-3 bg-blue-600 hover:bg-blue-500 text-white font-black uppercase text-xs rounded transition-all">Download JSON</button>
             <button onclick="exportRegistryCSV()" class="px-8 py-3 bg-slate-800 hover:bg-slate-700 text-white font-black uppercase text-xs rounded border border-white/10 transition-all">Export CSV</button>
             <button onclick="exportForensicPDF()" class="px-8 py-3 bg-red-600 hover:bg-red-500 text-white font-black uppercase text-xs rounded transition-all">

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -837,7 +837,7 @@ function exportChartAsJPG() {
 }
 
 // ─── EXPORT CENTER ───────────────────────────────────────────────────────────
-function exportForensicJSON() {
+function exportForensicJSON(returnBlob = false) {
   if (!lastScanResults) return showToast("No data available");
   const manifest = getChainManifest();
   const payload = {
@@ -847,6 +847,7 @@ function exportForensicJSON() {
   const blob = new Blob([JSON.stringify(payload, null, 4)], {
     type: "application/json",
   });
+  if (returnBlob) return blob;
   const a = document.createElement("a");
   a.href = URL.createObjectURL(blob);
   a.download = `Forensic_Report_${Date.now()}.json`;
@@ -854,13 +855,14 @@ function exportForensicJSON() {
   showToast("JSON Exported");
 }
 
-function exportRegistryCSV() {
+function exportRegistryCSV(returnBlob = false) {
   if (!lastScanResults) return showToast("Registry empty");
   let csv = "Start,End,Duration\n";
   lastScanResults.incidents.forEach(
     (i) => (csv += `${i.start},${i.end},${i.duration}\n`),
   );
   const blob = new Blob([csv], { type: "text/csv" });
+  if (returnBlob) return blob;
   const a = document.createElement("a");
   a.href = URL.createObjectURL(blob);
   a.download = `Registry_${Date.now()}.csv`;
@@ -868,7 +870,7 @@ function exportRegistryCSV() {
   showToast("CSV Exported");
 }
 
-async function exportForensicPDF() {
+async function exportForensicPDF(returnBlob = false) {
   if (!lastScanResults) return showToast("No scan data available for PDF");
 
   const { jsPDF } = window.jspdf;
@@ -949,8 +951,46 @@ async function exportForensicPDF() {
     doc.text(`Page ${i} of ${pageCount} - Confidential Forensic Data`, 14, 285);
   }
 
+  if (returnBlob) return doc.output("blob");
+
   doc.save(`Forensic_Report_${Date.now()}.pdf`);
   showToast("PDF Report Generated Successfully");
+}
+
+async function exportEvidenceZIP() {
+  if (!lastScanResults) return showToast("No data to export");
+  
+  showToast("Generating Evidence Package...");
+  
+  const jsonBlob = exportForensicJSON(true);
+  const csvBlob = exportRegistryCSV(true);
+  const pdfBlob = await exportForensicPDF(true);
+  
+  const formData = new FormData();
+  formData.append("pdf_file", pdfBlob, "report.pdf");
+  formData.append("csv_file", csvBlob, "registry.csv");
+  formData.append("json_file", jsonBlob, "report.json");
+  
+  try {
+    const token = localStorage.getItem("access_token");
+    const res = await fetch("http://127.0.0.1:8000/export/zip", {
+      method: "POST",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      body: formData
+    });
+    
+    if (!res.ok) throw new Error("ZIP export failed");
+    
+    const zipBlob = await res.blob();
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(zipBlob);
+    a.download = `Evidence_Package_${Date.now()}.zip`;
+    a.click();
+    showToast("Evidence Package Downloaded");
+  } catch (e) {
+    console.error(e);
+    showToast("ZIP Export Error");
+  }
 }
 
 // ─── UI & NAVIGATION UTILS ───────────────────────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -17,7 +17,8 @@ import json
 import logging
 import uuid
 import magic  # python-magic for MIME sniffing
-
+import io
+import zipfile
 load_dotenv()
 
 # ─── LOGGING ─────────────────────────────────────────────────────────────────
@@ -445,6 +446,39 @@ async def get_chain_status(
         },
         "documentation": "See CHAIN_OF_CUSTODY.md for full details"
     }
+
+
+@app.post("/export/zip")
+async def export_zip(
+    request: Request,
+    pdf_file: UploadFile = File(...),
+    csv_file: UploadFile = File(...),
+    json_file: UploadFile = File(...),
+    current_user: str = Depends(get_current_user),
+):
+    """
+    Creates an in-memory ZIP archive containing the generated PDF, CSV, and JSON reports.
+    Streams the ZIP file back to the client.
+    """
+    try:
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("report.pdf", await pdf_file.read())
+            zip_file.writestr("registry.csv", await csv_file.read())
+            zip_file.writestr("report.json", await json_file.read())
+            
+        zip_buffer.seek(0)
+        
+        return StreamingResponse(
+            iter([zip_buffer.getvalue()]),
+            media_type="application/zip",
+            headers={
+                "Content-Disposition": "attachment; filename=Evidence_Package.zip"
+            }
+        )
+    except Exception as e:
+        logger.error("ZIP export failed for user '%s': %s", current_user, str(e))
+        raise HTTPException(status_code=500, detail="Failed to generate ZIP archive.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description:
This PR implements the requested "Export Evidence Package (ZIP)" functionality, allowing forensic experts to download the PDF, CSV, and JSON reports as a single ZIP archive.

### Changes Made:

- **Backend (`main.py`)**: Added a new `POST /export/zip` endpoint that utilizes `io.BytesIO` and `zipfile` to dynamically construct an in-memory ZIP archive from the uploaded blob data, returning it efficiently as a single contiguous `StreamingResponse`.
- **Frontend (`dashboard.html`)**: Added the new primary "Export Evidence Package (ZIP)" button to the Export Center alongside the existing format buttons.
- **Frontend (`dashboard.js`)**: 
- Refactored `exportForensicJSON()`, `exportRegistryCSV()`, and `exportForensicPDF()` to accept a `returnBlob` flag, bypassing individual downloads when invoked as part of the ZIP batch process.
- Implemented `exportEvidenceZIP() 'to collect all three file blobs, package them into a "FormData` object, and fetch the new backend endpoint to trigger the final ZIP download seamlessly.

### Screenshots:
<img width="1916" height="891" alt="image" src="https://github.com/user-attachments/assets/128f3869-720c-4ef7-a15d-9ba35c1e7d89" />

Fixes #131 